### PR TITLE
Fix get terms

### DIFF
--- a/wordpress-objects.post.php
+++ b/wordpress-objects.post.php
@@ -308,9 +308,17 @@ class Post {
 	 */
 	public function get_terms( $taxonomy, $args = array() ) {
 		return array_map(
-			function( $term ) use ( $taxonomy ) {
+			function( $term ) use ( $taxonomy, $args ) {
 				try {
-					return Term::get_by_slug( $term->slug, $taxonomy );
+					if ( isset( $args['fields'] ) ) {
+						if ( $args['fields'] === 'ids' ) {
+							return Term::get_by_id( $term, $taxonomy );
+						}
+						if ( $args['fields'] === 'names' ) {
+							return Term::get_by_name( $term, $taxonomy );
+						}
+					}
+					return Term::get_by_id( $term->term_id, $taxonomy );
 				} catch ( Exception $e ) {
 					return null;
 				}

--- a/wordpress-objects.post.php
+++ b/wordpress-objects.post.php
@@ -3,6 +3,7 @@
 class Post {
 
 	public $_post;
+	
 	protected static $posts;
 
 	/**
@@ -11,45 +12,48 @@ class Post {
 	 */
 	public function __construct( $post_id ) {
 
-		if ( empty( $post_id ) )
+		if ( empty( $post_id ) ) {
 			throw new Exception( '$post_id empty' );
+		}
 
 		$this->_post = get_post( $post_id );
 
-		if ( ! $this->_post )
+		if ( ! $this->_post ) {
 			throw new Exception( 'Post not found' );
+		}
 	}
 
 	public function __get( $name ) {
 
-		if ( in_array( $name, array( 'post_name', 'post_title', 'ID', 'post_author', 'post_type', 'post_status'  ) ) )
+		if ( in_array( $name, array( 'post_name', 'post_title', 'ID', 'post_author', 'post_type', 'post_status' ) ) ) {
 			throw new Exception( 'Trying to access wp_post object properties from Post object' );
+		}
 	}
 
 	/**
 	 * Get a post
-	 * 
+	 *
 	 * @param  int $id
 	 * @return Post|null if not exists
 	 */
 	public static function get( $id ) {
-		if ( ! isset( static::$posts[$id] ) ) {
+		if ( ! isset( static::$posts[ $id ] ) ) {
 			$class = get_called_class();
 
 			try {
-				static::$posts[$id] = new $class( $id );
+				static::$posts[ $id ] = new $class( $id );
 			} catch ( Exception $e ) {
-				static::$posts[$id] = null;
+				static::$posts[ $id ] = null;
 			}
 
 		}
 
-		return static::$posts[$id];
+		return static::$posts[ $id ];
 	}
 
 	/**
 	 * Get many posts from a query
-	 * 
+	 *
 	 * @param  array $args
 	 * @return Post[]
 	 */
@@ -74,7 +78,7 @@ class Post {
 
 	/**
 	 * Get an post from args
-	 * 
+	 *
 	 * @param  array $args
 	 * @return Post
 	 */
@@ -103,14 +107,16 @@ class Post {
 	 */
 	public function get_parent() {
 
-		if ( $this->_post->post_parent )
+		if ( $this->_post->post_parent ) {
 			return new Post( $this->_post->post_parent );
+		}
 
 		return null;
 	}
 
 	/**
 	 * Get the children of the post (if any)
+	 *
 	 * @return StdClass[]
 	 */
 	public function get_children() {
@@ -164,6 +170,7 @@ class Post {
 
 	/**
 	 * Set the post date of the post
+	 *
 	 * @param int $time PHP timestamp
 	 */
 	public function set_date( $time ) {
@@ -233,8 +240,9 @@ class Post {
 
 	public function get_author() {
 
-		if ( $this->_post->post_author )
+		if ( $this->_post->post_author ) {
 			return User::get( $this->_post->post_author );
+		}
 
 		return null;
 	}
@@ -286,15 +294,17 @@ class Post {
 	 */
 	public function add_comment( $comment_text, $user_id ) {
 
-		if ( empty( $comment_text ) || empty( $user_id) )
+		if ( empty( $comment_text ) || empty( $user_id ) ) {
 			throw new Exception( 'Not enough data' );
+		}
 
 		$comment = array( 'comment_post_ID' => $this->get_id(), 'user_id' => $user_id, 'comment_content' => esc_attr( $comment_text ) );
 
 		$result = wp_insert_comment( $comment );
 
-		if ( ! is_numeric( $result ) )
+		if ( ! is_numeric( $result ) ) {
 			throw new Exception( 'wp_insert_post failed: ' . $result );
+		}
 
 		return $result;
 	}
@@ -310,10 +320,10 @@ class Post {
 		return array_map(
 			function( $term ) use ( $taxonomy, $args ) {
 				try {
-					if ( isset( $args['fields'] ) && in_array( $args['fields'], array( 'ids', 'names' ) ) ) {
-						return $term;
+					if ( is_object( $term ) ) {
+						return Term::get_by_id( $term->term_id, $taxonomy );
 					}
-					return Term::get_by_id( $term->term_id, $taxonomy );
+					return $term;
 				} catch ( Exception $e ) {
 					return null;
 				}
@@ -325,7 +335,7 @@ class Post {
 	/**
 	 * Add a single term to a post.
 	 *
-	 * @param Term $terms Term Object
+	 * @param Term $term Term Object
 	 * @return array|WP_Error Affected Term IDs.
 	 */
 	public function add_term( $term ) {
@@ -336,7 +346,8 @@ class Post {
 	 * Bulk add terms to a post.
 	 *
 	 * @param string $taxonomy Taxonomy
-	 * @param array $terms Term objects
+	 * @param array  $terms    Term objects
+	 * @return array
 	 */
 	public function add_terms( $taxonomy, $terms ) {
 
@@ -358,8 +369,8 @@ class Post {
 	 * Will delete all terms for a given taxonomy.
 	 * Adds all passed terms or  overwrite existing terms,
 	 *
-	 * @param  array  $terms Term
-	 * @param  string  $terms Tax
+	 * @param  array        $terms Term
+	 * @param  string|array $terms Tax
 	 * @return array|WP_Error Affected Term IDs.
 	 */
 	public function reset_terms( $taxonomy, $terms = array() ) {
@@ -381,7 +392,7 @@ class Post {
 	/**
 	 * Remove a post term.
 	 *
-	 * @param  Term $term.
+	 * @param  Term $term .
 	 * @return bool|WP_Error True on success, false or WP_Error on failure.
 	 */
 	public function remove_term( $term ) {

--- a/wordpress-objects.post.php
+++ b/wordpress-objects.post.php
@@ -310,13 +310,8 @@ class Post {
 		return array_map(
 			function( $term ) use ( $taxonomy, $args ) {
 				try {
-					if ( isset( $args['fields'] ) ) {
-						if ( $args['fields'] === 'ids' ) {
-							return Term::get_by_id( $term, $taxonomy );
-						}
-						if ( $args['fields'] === 'names' ) {
-							return Term::get_by_name( $term, $taxonomy );
-						}
+					if ( isset( $args['fields'] ) && in_array( $args['fields'], array( 'ids', 'names' ) ) ) {
+						return $term;
 					}
 					return Term::get_by_id( $term->term_id, $taxonomy );
 				} catch ( Exception $e ) {

--- a/wordpress-objects.post.php
+++ b/wordpress-objects.post.php
@@ -318,7 +318,7 @@ class Post {
 	 */
 	public function get_terms( $taxonomy, $args = array() ) {
 		return array_map(
-			function( $term ) use ( $taxonomy, $args ) {
+			function( $term ) use ( $taxonomy ) {
 				try {
 					if ( is_object( $term ) ) {
 						return Term::get_by_id( $term->term_id, $taxonomy );

--- a/wordpress-objects.term.php
+++ b/wordpress-objects.term.php
@@ -11,9 +11,9 @@ class Term {
 	protected static $taxonomy = null;
 
 
-	public static function get_by_name( $slug, $taxonomy = null ) {
+	public static function get_by_name( $name, $taxonomy = null ) {
 
-		$term = get_term_by( 'name', $slug, $taxonomy ? $taxonomy : static::$taxonomy );
+		$term = get_term_by( 'name', $name, $taxonomy ? $taxonomy : static::$taxonomy );
 
 		$class = get_called_class();
 
@@ -23,6 +23,15 @@ class Term {
 	public static function get_by_slug( $slug, $taxonomy = null ) {
 
 		$term = get_term_by( 'slug', $slug, $taxonomy ? $taxonomy : static::$taxonomy );
+
+		$class = get_called_class();
+
+		return new $class( $term->term_id, $taxonomy ? $taxonomy : static::$taxonomy );
+	}
+
+	public static function get_by_id( $term_id, $taxonomy = null ) {
+
+		$term = get_term_by( 'id', $term_id, $taxonomy ? $taxonomy : static::$taxonomy );
 
 		$class = get_called_class();
 


### PR DESCRIPTION
If you're using the `$args['fields']` functionality on `$post->get_terms()` you can sometimes just get back an array of integers or strings. This adds logic to determine what to send back in the method result eg. only return a `Term` object if term is an object.