### PR TITLE
Use new self instead of new Post

### DIFF
--- a/wordpress-objects.post.php
+++ b/wordpress-objects.post.php
@@ -108,7 +108,7 @@ class Post {
 	public function get_parent() {
 
 		if ( $this->_post->post_parent ) {
-			return new Post( $this->_post->post_parent );
+			return new self( $this->_post->post_parent );
 		}
 
 		return null;


### PR DESCRIPTION
So that if you extend a new custom object with Post you get the same kind of object.
We use this so that for every CPT one could have a custom object.